### PR TITLE
Make homepage html title "Klaw"

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -1,3 +1,4 @@
+<title>Klaw</title>
 {% extends "base.html" %}{% block extrahead %} {{ super() }} {% endblock %} {%
 block body %} {{ super() }}
 <div class="min-h-screen flex flex-col">


### PR DESCRIPTION
By default if a title isn't set for a given page, sphinx has a default format it tries to follow which includes the project name, page name and some format for it. In our custom index page the title turned out however to be " - Klaw" which isn't optimal for SEO and this commit changes the title to just "Klaw"