### PR TITLE
Add variable for admonition background to fix appearance in dark mode.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,7 @@ light_css_variables = {
   "color-brand-primary": _color_definitions["grey-80"],
   "color-brand-content": _color_definitions["grey-80"],
   "color-sidebar-item-background--current": _color_definitions["grey-5"],
+  "color-admonition-background": "white",
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
## Small visual 🐛 fix:

- `color-admonition-background` has a  white color as standard for OS light mode
- we're reusing the `light_css_variables` also for dark-mode, which is applied based on OS setting  (or local storage)
- the background needed to be set explicit so it's also applied when dark mode is used, otherwise the background was black and text not readable

I checked the site visually (running it locally) with my OS settings for dark and light mode and it looks good. 