### PR TITLE
Release 1.1.0 with multi maven modules in klaw.

### DIFF
--- a/docs/docs/run-source.rst
+++ b/docs/docs/run-source.rst
@@ -13,7 +13,7 @@ Klaw is a Java project, you will need `Maven <https://maven.apache.org/>`_ insta
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with a base64 string in module 'core' (application.properties)
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with the above base64 string in cluster-api (application.properties) module as well.
 
-2. Build the project by running ``./mvnw clean package`` from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
+2. Build the project by running ``./mvnw clean package`` for Linux(bash) Or ``mvnw clean package`` for Windows, from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
 
 3. Start the API component by running its JAR file::
 

--- a/docs/docs/run-source.rst
+++ b/docs/docs/run-source.rst
@@ -3,24 +3,27 @@ Run Klaw from source
 
 Klaw is a Java project, you will need `Maven <https://maven.apache.org/>`_ installed to run this project from source.
 
-1. Download the latest code from both repositories:
+1. Download the latest code from the below repository:
 
    * https://github.com/aiven/klaw
-   * https://github.com/aiven/klaw-cluster-api
 
-   .. tip:: You can also clone both repositories to use the "bleeding edge" version if you wish.
+   .. tip:: You can also clone repository to use the "bleeding edge" version if you wish.
 
-2. Build both projects by running ``mvn clean package`` from the top level of each project directory. This will build a JAR file in the ``target/`` directory of each project.
+2. Configure Cluster Api access
+    - Configure the property ``klaw.clusterapi.access.base64.secret`` with a base64 string in module 'core' (application.properties)
+    - Configure the property ``klaw.clusterapi.access.base64.secret`` with the above base64 string in cluster-api (application.properties) module as well.
+
+2. Build the project by running ``mvn clean package`` from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
 
 3. Start the API component by running its JAR file::
 
-        java -jar klaw-clusterapi-1.0.0.jar
+        java -jar klaw-clusterapi-1.1.0.jar
 
    .. note:: to pass additional configuration, pass an additional parameter like ``--spring.config.location=classes/application.properties``
 
 4. Start the web UI by running its JAR file::
 
-        java -jar klaw-1.0.0.jar
+        java -jar klaw-1.1.0.jar
 
 5. Navigate to the web interface ``http://localhost:9097/``
 

--- a/docs/docs/run-source.rst
+++ b/docs/docs/run-source.rst
@@ -13,17 +13,17 @@ Klaw is a Java project, you will need `Maven <https://maven.apache.org/>`_ insta
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with a base64 string in module 'core' (application.properties)
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with the above base64 string in cluster-api (application.properties) module as well.
 
-2. Build the project by running ``mvn clean package`` from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
+2. Build the project by running ``./mvnw clean package`` from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
 
 3. Start the API component by running its JAR file::
 
-        java -jar klaw-clusterapi-1.1.0.jar
+        java -jar klaw-clusterapi-<version>.jar
 
    .. note:: to pass additional configuration, pass an additional parameter like ``--spring.config.location=classes/application.properties``
 
 4. Start the web UI by running its JAR file::
 
-        java -jar klaw-1.1.0.jar
+        java -jar klaw-<version>.jar
 
 5. Navigate to the web interface ``http://localhost:9097/``
 

--- a/docs/docs/run-source.rst
+++ b/docs/docs/run-source.rst
@@ -13,7 +13,7 @@ Klaw is a Java project, you will need `Maven <https://maven.apache.org/>`_ insta
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with a base64 string in module 'core' (application.properties)
     - Configure the property ``klaw.clusterapi.access.base64.secret`` with the above base64 string in cluster-api (application.properties) module as well.
 
-2. Build the project by running ``./mvnw clean package`` for Linux(bash) Or ``mvnw clean package`` for Windows, from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
+2. Build the project by running ``./mvnw clean package`` for Linux(bash) or ``mvnw clean package`` for Windows, from the top level of the project directory. This will build JAR files in the ``target/`` directories of each modules 'core' and 'cluster-api'.
 
 3. Start the API component by running its JAR file::
 


### PR DESCRIPTION
Klaw as Maven multi-module project. Modules : 'core' and 'cluster-api'.
'core' Core Api with user interface and cluster-api connectivity
'cluster-api' module is cloned from main branch of repo https://github.com/aiven/klaw-cluster-api. Cluster Api with connectivity to kafka clusters

This removes the dependency on cluster-api git repository.