### PR TITLE
Promotion of Topics and Schemas

### DIFF
--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -4,7 +4,7 @@ Promotion
 
 Klaw allows users to control the creation of resources in their Kafka environment through the concept of promotion.
 
-- This adds an extra layer of security avoiding risk of manually duplicating entries across environments.
+- This adds an extra layer of security, avoiding the risk of manually duplicating entries across environments.
 - The requests are properly reviewed and verified by another pair of eyes, maintaining sanity of the application.
 - Information is audited. Who is raising the request, when it has been created, and who approved and when. Helps in identifying problems during unexpected behaviour of system.
 - By maintaining a history of applied changes, easy track back on the evolution of a configuration.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -68,7 +68,7 @@ Configure environment promotion
     How does Force Register work?
         When promoting a schema to a higher environment, the ``Force Register`` Schema option allows registration even if it is not compatible with previous schemas.
         If this option is selected, then Klaw will change the compatibility of the topic to ``NONE``, register the new schema and then revert to the previous topic compatibility.
-        If the topic compatibility is not set it will fall back to the global compatibility however Klaw will not change the global compatibility.
+        If the topic compatibility is not set, it will fall back to the global compatibility. However, Klaw will not change the global compatibility.
 
 
 Note that any request raised cannot be approved by the same user, rather it has to be a different user from the same team.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -49,7 +49,7 @@ Configure environment promotion
         6. A Topic request is now created for team members to review and approve under Approvals.
 
     Schema Promotion
-      Under the ``Topic Overview`` the schema can be requested and viewed for an individual topic and as of Release 2.0.0 the ability to promote existing schemas to higher level environments is also available.
+      Under the ``Topic Overview``, the schema can be requested and viewed for an individual topic. As of Release 2.0.0, the ability to promote existing schemas to higher-level environments is also available. The requester can select a particular version of the schema to promote from the lower environment to the higher environment.
       The requester can select a particular version of the schema to promote from the lower environment to the higher environment.
 
 

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -66,7 +66,7 @@ Configure environment promotion
         8. A schema request is now created for team members to review and approve under Approvals.
 
     How does Force Register work?
-        The ``Force Register Schema`` option, for use when a schema needs to be promoted to the higher environment but which does not meet the compatibility of the previous schemas.
+        When promoting a schema to a higher environment, the ``Force Register`` Schema option allows registration even if it is not compatible with previous schemas.
         If this option is selected, then klaw will change the compatibility of the topic to ``NONE``, register the new schema and then revert to the previous topic compatibility.
         If the topic compatibility is not set it will fall back to the global compatibility however Klaw will not change the global compatibility.
 

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -18,7 +18,7 @@ Configure environment promotion
       Found under **Dashboard -> Settings**, the Superadmin user has the ability to define the ``Tenant Model``, which configures which environments promote to the next environment in your organization.
       Each resource Topic/Schema must already be created by the superadmin under ``Environments`` before being added to the ``Tenant Model`` or the server will reject the configuration.
       Below in the example we can see that the Kafka Topic environments have been defined as 'Dev' & 'TST' the order is also specified which is the order that will be enforced in the promotion of topics.
-      Similarily the Schema Registry environments have all been defined and placed in order.
+      Similarly, the Schema Registry environments have all been defined and placed in order.
 ```
 {
   "tenantModel":

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -10,7 +10,7 @@ Klaw allows users to control the creation of resources in their Kafka environmen
 - By maintaining a history of applied changes, easy track back on the evolution of a configuration.
 
 
-Promotion of resources are administered by the resource owners, each team has the ability to promote a topic, schema or connector from one environment to the next.
+The resource owners administer promotion of resources, and each team can promote a topic, schema or connector from one environment to the next.
 
 Configure environment promotion
 -------------------------------

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -38,7 +38,7 @@ Configure environment promotion
 
     Topic Promotion
       Once a topic is created in the base environment it is then possible to promote this to the next environment.
-      This will create a promotion request that can be reviewed and approved or declined by the requesters team mates. Each created environment is able to be seen in the same ``Topic Overview`` where the topic can be promoted.
+      This will create a promotion request that can be reviewed, approved, or declined by the requester's teammates. Each created environment can be seen in the same ``Topic Overview`` where the topic can be promoted.
 
         How to Promote a Topic
         1. Select *Topics* on the navigation bar.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -54,7 +54,8 @@ Configure environment promotion
       The requester can select a particular version of the schema to promote from the lower environment to the higher environment.
 
 
-        How to Promote a Schema
+        How to Promote a Schema:
+        
         1. Select *Topics* on the navigation bar.
         2. Select the specific Kafka Topic you wish to promote a Schema to the higher environment.
         3. Select the **Schema** tab under the main Topic section.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -67,7 +67,7 @@ Configure environment promotion
 
     How does Force Register work?
         When promoting a schema to a higher environment, the ``Force Register`` Schema option allows registration even if it is not compatible with previous schemas.
-        If this option is selected, then klaw will change the compatibility of the topic to ``NONE``, register the new schema and then revert to the previous topic compatibility.
+        If this option is selected, then Klaw will change the compatibility of the topic to ``NONE``, register the new schema and then revert to the previous topic compatibility.
         If the topic compatibility is not set it will fall back to the global compatibility however Klaw will not change the global compatibility.
 
 

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -40,7 +40,8 @@ Configure environment promotion
       Once a topic is created in the base environment it is then possible to promote this to the next environment.
       This will create a promotion request that can be reviewed, approved, or declined by the requester's teammates. Each created environment can be seen in the same ``Topic Overview`` where the topic can be promoted.
 
-        How to Promote a Topic
+        How to Promote a Topic:
+        
         1. Select *Topics* on the navigation bar.
         2. Select the specific Kafka Topic you wish to promote to the higher environment.
         3. A button is available to promote the topic to the next environment where a higher environment has been configured. ``Promote to [Next Environment]``

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -2,7 +2,7 @@ Promotion
 =========
 
 
-Klaw allows users to control the creation of resources in their Kafka environment through a concept of promotion.
+Klaw allows users to control the creation of resources in their Kafka environment through the concept of promotion.
 
 - This adds an extra layer of security avoiding risk of manually duplicating entries across environments.
 - The requests are properly reviewed and verified by another pair of eyes, maintaining sanity of the application.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -15,7 +15,7 @@ Promotion of resources are administered by the resource owners, each team has th
 Configure environment promotion
 -------------------------------
     Server Configuration
-      Found under **Dashboard -> Settings** the Superadmin user has the ability to define the ``Tenant Model`` which configures which environments promote to the next environment in your organisation.
+      Found under **Dashboard -> Settings**, the Superadmin user has the ability to define the ``Tenant Model``, which configures which environments promote to the next environment in your organization.
       Each resource Topic/Schema must already be created by the superadmin under ``Environments`` before being added to the ``Tenant Model`` or the server will reject the configuration.
       Below in the example we can see that the Kafka Topic environments have been defined as 'Dev' & 'TST' the order is also specified which is the order that will be enforced in the promotion of topics.
       Similarily the Schema Registry environments have all been defined and placed in order.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -17,7 +17,7 @@ Configure environment promotion
     Server Configuration
       Found under **Dashboard -> Settings**, the Superadmin user has the ability to define the ``Tenant Model``, which configures which environments promote to the next environment in your organization.
       Each resource Topic/Schema must already be created by the superadmin under ``Environments`` before being added to the ``Tenant Model`` or the server will reject the configuration.
-      Below in the example we can see that the Kafka Topic environments have been defined as 'Dev' & 'TST' the order is also specified which is the order that will be enforced in the promotion of topics.
+      The below example defines the Kafka Topic environments as 'Dev' & 'TST' and specifies the order that will be enforced in the promotion of topics.
       Similarly, the Schema Registry environments have all been defined and placed in order.
 ```
 {

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -1,0 +1,72 @@
+Promotion
+=========
+
+
+Klaw allows users to control the creation of resources in their Kafka environment through a concept of promotion.
+
+- This adds an extra layer of security avoiding risk of manually duplicating entries across environments.
+- The requests are properly reviewed and verified by another pair of eyes, maintaining sanity of the application.
+- Information is audited. Who is raising the request, when it has been created, and who approved and when. Helps in identifying problems during unexpected behaviour of system.
+- By maintaining a history of applied changes, easy track back on the evolution of a configuration.
+
+
+Promotion of resources are administered by the resource owners, each team has the ability to promote a topic, schema or connector from one environment to the next.
+
+Configure environment promotion
+-------------------------------
+    Server Configuration
+      Found under **Dashboard -> Settings** the Superadmin user has the ability to define the ``Tenant Model`` which configures which environments promote to the next environment in your organisation.
+      Each resource Topic/Schema must already be created by the superadmin under ``Environments`` before being added to the ``Tenant Model`` or the server will reject the configuration.
+      Below in the example we can see that the Kafka Topic environments have been defined as 'Dev' & 'TST' the order is also specified which is the order that will be enforced in the promotion of topics.
+      Similarily the Schema Registry environments have all been defined and placed in order.
+```
+{
+  "tenantModel":
+    {
+      "tenantName": "default",
+      "baseSyncEnvironment": "DEV",
+      "orderOfTopicPromotionEnvsList": ["DEV", "TST"],
+      "requestTopicsEnvironmentsList": ["DEV", "TST"],
+      "orderOfSchemaPromotionEnvsList" : [ "DEV_SCH", "TST_SCH" ],
+      "requestSchemaEnvironmentsList" : [ "DEV_SCH", "TST_SCH" ]
+    }
+}
+
+```
+
+
+
+    Topic Promotion
+      Once a topic is created in the base environment it is then possible to promote this to the next environment.
+      This will create a promotion request that can be reviewed and approved or declined by the requesters team mates. Each created environment is able to be seen in the same ``Topic Overview`` where the topic can be promoted.
+
+        How to Promote a Topic
+        1. Select *Topics* on the navigation bar.
+        2. Select the specific Kafka Topic you wish to promote to the higher environment.
+        3. A button is available to promote the topic to the next environment where a higher environment has been configured. ``Promote to [Next Environment]``
+        4. Configure the number of Partitions and Replication Factor for the higher environment in the drop downs provided.
+        5. Confirm the promotion to the next environment by selecting ``Submit Promotion to [Next Environment]``
+        6. A Topic request is now created for team members to review and approve under Approvals.
+
+    Schema Promotion
+      Under the ``Topic Overview`` the schema can be requested and viewed for an individual topic and as of Release 2.0.0 the ability to promote existing schemas to higher level environments is also available.
+      The requester can select a particular version of the schema to promote from the lower environment to the higher environment.
+
+
+        How to Promote a Schema
+        1. Select *Topics* on the navigation bar.
+        2. Select the specific Kafka Topic you wish to promote a Schema to the higher environment.
+        3. Select the **Schema** tab under the main Topic section.
+        4. A button is available to promote a schema to a higher environment where a higher environment has been configured. ``Promote to [Next Environment]``
+        5. Select the version of the Schema you wish to promote to the higher environment, this Schema will be available for the team to review when approving or declining the request.
+        6. Optionally if the Schema you wish to promote is not compatible with the existing schemas on that topic ``Force Register Schema`` can be used to register the Schema.
+        7. Confirm the promotion to the next environment by selecting ``Submit Promotion to [Next Environment]``
+        8. A schema request is now created for team members to review and approve under Approvals.
+
+    How does Force Register work?
+        The ``Force Register Schema`` option, for use when a schema needs to be promoted to the higher environment but which does not meet the compatibility of the previous schemas.
+        If this option is selected, then klaw will change the compatibility of the topic to ``NONE``, register the new schema and then revert to the previous topic compatibility.
+        If the topic compatibility is not set it will fall back to the global compatibility however Klaw will not change the global compatibility.
+
+
+Note that any request raised cannot be approved by the same user, rather it has to be a different user from the same team.

--- a/docs/docs/concepts/promotion.rst
+++ b/docs/docs/concepts/promotion.rst
@@ -61,7 +61,7 @@ Configure environment promotion
         3. Select the **Schema** tab under the main Topic section.
         4. A button is available to promote a schema to a higher environment where a higher environment has been configured. ``Promote to [Next Environment]``
         5. Select the version of the Schema you wish to promote to the higher environment, this Schema will be available for the team to review when approving or declining the request.
-        6. Optionally if the Schema you wish to promote is not compatible with the existing schemas on that topic ``Force Register Schema`` can be used to register the Schema.
+        6. Optionally, if the Schema you wish to promote is not compatible with the existing schemas on that topic, ``Force Register Schema`` can be used to register the Schema.
         7. Confirm the promotion to the next environment by selecting ``Submit Promotion to [Next Environment]``
         8. A schema request is now created for team members to review and approve under Approvals.
 

--- a/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.rst
@@ -6,7 +6,7 @@ This section provides you with information on how to connect Aiven for Apache Ka
 Prerequisite
 ------------
 
-* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
+* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
 * A running Aiven for Apache Kafka® service. See `Getting started with Aiven for Apache Kafka for more information <https://docs.aiven.io/docs/products/kafka/getting-started.html>`_.
 * Configured `Java keystore and truststore containing the service SSL certificates <https://docs.aiven.io/docs/products/kafka/howto/keystore-truststore.html>`_ to access Apache Kafka.  
 

--- a/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.rst
@@ -6,7 +6,7 @@ This section provides you with information on how to connect Aiven for Apache Ka
 Prerequisite
 ------------
 
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 * A running Aiven for Apache Kafka® service. See `Getting started with Aiven for Apache Kafka for more information <https://docs.aiven.io/docs/products/kafka/getting-started.html>`_.
 * Configured `Java keystore and truststore containing the service SSL certificates <https://docs.aiven.io/docs/products/kafka/howto/keystore-truststore.html>`_ to access Apache Kafka.  
 
@@ -30,7 +30,7 @@ Follow the steps below to configure and connect to an Aiven for Apache Kafka® a
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. Click **Add Environment** and enter the details to add your Kafka environment. 
 7. Enter an environment name, set the cluster you added from the drop-down list, and configure partitions and replication factor, and tenat (set to default). 
-8. Copy the **Cluster ID** from the **Clusters** page using the copy icon.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
 9. Open the ``application.properties`` file located in the `klaw/cluster-api/src/main/resources` directory.
 10. Depending on the SASL mechanism you are using, copy one of the below properties, replace ``clusterid`` with the copied cluster id, and save the ``application.properties`` file.
 ::

--- a/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.rst
@@ -7,7 +7,7 @@ This section provides you with information on how to connect Aiven for Apache Ka
 Prerequisite
 ------------
 
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 * A running Aiven for Apache Kafka® service. See `Getting started with Aiven for Apache Kafka for more information <https://docs.aiven.io/docs/products/kafka/getting-started.html>`_.
 * Configured `Java keystore and truststore containing the service SSL certificates <https://docs.aiven.io/docs/products/kafka/howto/keystore-truststore.html>`_ to access Apache Kafka.  
 
@@ -31,7 +31,7 @@ Follow the steps below to configure and connect to an Aiven for Apache Kafka® a
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. Click **Add Environment** and enter the details to add your Kafka environment. 
 7. Enter an environment name, set the cluster you added from the drop-down list, and configure partitions and replication factor, and tenat (set to default). 
-8. Copy the **Cluster ID** from the **Clusters** page using the copy icon.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
 9. Open the ``application.properties`` file located in the `klaw/cluster-api/src/main/resources` directory.
 10. Configure the SSL properties to connect to Aiven for Apache Kafka® clusters by copying and editing the following lines. 
     ::    

--- a/docs/docs/howto/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.rst
@@ -3,6 +3,9 @@ Connect with Aiven for Apache Kafka® Connect service
 Aiven for Apache Kafka® Connect is a fully managed distributed Apache Kafka® integration component, deployable in the cloud of your choice. Apache Kafka Connect lets you integrate your existing data sources and sinks with Apache Kafka.
 
 This section provides you with information on how to connect Aiven for Apache Kafka Connect service with Klaw using SSL protocol. 
+Prerequisite
+------------
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 
 Configure and connect with SSL protocol
 ---------------------------------------
@@ -26,8 +29,9 @@ Follow the steps below to configure and connect an Aiven for Apache Kafka Connec
 4. Click **Save**. 
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. In the **Kafka Connect Environments** section, click **Add Environment** and enter the details to add your schema registry environment. Click **Save**. 
-7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules. 
-8. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines:
+7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
+9. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines. Where the **clusterid** should be replaced by the value copied in step 8.
 ::    
     
         clusterid.kafkassl.keystore.location=client.keystore.p12
@@ -42,11 +46,11 @@ Follow the steps below to configure and connect an Aiven for Apache Kafka Connec
 - Replace ``client.keystore.p12`` with the path for the keystore and ``klaw1234`` with the password configured for the keystore file.
 - Replace ``client.truststore.jks`` with the path for the truststore and ``klaw1234`` with the password configured for the truststore file.
 - Save the ``application.properties`` file.
-9. Additionally, in the `cluster-api` (klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console::
+10. Additionally, in the `cluster-api` (klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console::
 ::
     
     clusterid.klaw.kafkaconnect.credentials=username:password
 
 Replace clusterid with Klaw cluster Id copied from Klaw UI.
 
-10. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Aiven for Apache Kafka Connect service using SSL protocol.
+11. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Aiven for Apache Kafka Connect service using SSL protocol.

--- a/docs/docs/howto/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.rst
@@ -4,7 +4,7 @@ This section provides information on how to connect a Karapace schema registry u
 
 Prerequisite
 ------------
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 * Import the Karapce scehma registry public certificate to truststore of Klaw. For more information, see `Java keystore and truststore containing the service SSL certificates <https://docs.aiven.io/docs/products/kafka/howto/keystore-truststore.html>`_.
 
 Configure and connect SSL protocol
@@ -26,8 +26,9 @@ Follow the steps below to configure and connect to a Karapace schema registry cl
 4. Click **Save**. 
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. In the **Schema Registry Environments** section, click **Add Environment** and enter the details to add your schema registry environment. Click **Save**. 
-7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules. 
-8. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines. 
+7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
+9. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines. Where the **clusterid** should be replaced by the value copied in step 8.
 ::    
 
         clusterid.kafkassl.keystore.location=client.keystore.p12
@@ -43,12 +44,12 @@ Follow the steps below to configure and connect to a Karapace schema registry cl
 - Replace ``client.truststore.jks`` with the path for the truststore and ``klaw1234`` with the password configured for the truststore file.
 - Save the ``application.properties`` file.
 
-9. Additionally, in the `cluster-api` (klaw/cluster-api/src/main/resources) module, configure Karapace credentials copied from Aiven console::
+10. Additionally, in the `cluster-api` (klaw/cluster-api/src/main/resources) module, configure Karapace credentials copied from Aiven console::
 ::
 
     clusterid.klaw.schemaregistry.credentials=username:password
 
 Replace clusterid with Klaw cluster Id copied from Klaw UI.
 
-10. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Kafka cluster using SSL protocol.
+11. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Kafka cluster using SSL protocol.
 

--- a/docs/docs/howto/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.rst
@@ -5,7 +5,7 @@ This section provides you with information on how to connect Apache Kafka cluste
 
 Prerequisite
 ------------
-* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
+* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
 
 Configure and connect using SASL protocol
 -----------------------------------------

--- a/docs/docs/howto/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.rst
@@ -5,7 +5,7 @@ This section provides you with information on how to connect Apache Kafka cluste
 
 Prerequisite
 ------------
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 
 Configure and connect using SASL protocol
 -----------------------------------------
@@ -26,7 +26,7 @@ Follow the steps below to configure and connect to an Apache Kafka® cluster in 
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. Click **Add Environment** and enter the details to add your Kafka environment. 
 7. Enter an environment name, set the cluster you added from the drop-down list, and configure partitions and replication factor, and tenat (set to default). 
-8. Copy the **Cluster ID** from the **Clusters** page using the copy icon.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
 9. Open the ``application.properties`` file located in the `klaw/cluster-api/src/main/resources` directory.
 10. Depending on the SASL mechanism you are using, copy one of the below properties, replace ``clusterid`` with the copied cluster id, and save the ``application.properties`` file.
     ::

--- a/docs/docs/howto/clusterconnectivity/kafka-cluster-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/kafka-cluster-ssl-protocol.rst
@@ -7,7 +7,7 @@ This section provides you with information on how to connect Apache Kafka cluste
 
 Prerequisite
 ------------
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 
 
 Configure and connect using SSL protocol
@@ -28,7 +28,7 @@ Follow the steps below to configure and connect to an Apache Kafka® cluster in 
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. Click **Add Environment** and enter the details to add your Kafka environment. 
 7. Enter an environment name, set the cluster you added from the drop-down list, and configure partitions and replication factor, and tenat (set to default).ß
-8. Copy the **Cluster ID** from the **Clusters** page using the copy icon.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
 9. Open the ``application.properties`` file located in the `klaw/cluster-api/src/main/resources` directory.
 10. Configure the SSL properties to connect to Apache Kafka clusters by copying and editing the following lines:
 ::

--- a/docs/docs/howto/clusterconnectivity/sr-cluster-ssl-protocol.rst
+++ b/docs/docs/howto/clusterconnectivity/sr-cluster-ssl-protocol.rst
@@ -5,7 +5,7 @@ This section provides information on how to connect a Schema Registry cluster us
 
 Prerequisite
 ------------
-* Set up the connection between the Klaw APIs (Core API and Cluster API), see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate.
+* Set up the connection between the Klaw APIs (Core API and Cluster API) to use secure SSL, see :doc:`klaw-core-with-clusterapi`. This involves configuring the ``klaw.clusterapi.url`` setting in the Klaw UI and testing the connectivity to ensure the two APIs can communicate over https.
 * Import the Schema registry public certificate to truststore of Klaw. Ensure that the certificates used in the keystore and truststore are signed by the same CA.
 
 
@@ -26,8 +26,9 @@ Follow the steps below to configure and connect to a Schema Registry cluster wit
 4. Click **Save**. 
 5. Add the cluster to the preferred environment. Click **Environments** from the **Environments** drop-down menu.
 6. In the **Schema Registry Environments** section, click **Add Environment** and enter the details to add your schema registry environment. Click **Save**. 
-7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules. 
-8. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines. 
+7. Open the ``application.properties`` file for `core`` (klaw/core/src/main/resources) and `cluster-api` (klaw/cluster-api/src/main/resources) modules.
+8. Copy the **Cluster ID** from the **Clusters** page using the copy icon that is available on the right hand side of the each cluster row.
+9. Configure the SSL properties to connect to Schema Registry cluster by copying and editing the following lines. Where the **clusterid** should be replaced by the value copied in step 8.
 ::    
     
         clusterid.kafkassl.keystore.location=client.keystore.p12
@@ -42,4 +43,4 @@ Follow the steps below to configure and connect to a Schema Registry cluster wit
 - Replace ``client.keystore.p12`` with the path for the keystore and ``klaw1234`` with the password configured for the keystore file.
 - Replace ``client.truststore.jks`` with the path for the truststore and ``klaw1234`` with the password configured for the truststore file.
 - Save the ``application.properties`` file.
-9. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Kafka cluster using SSL protocol.
+10. Re-deploy the Cluster API with the updated configuration. This will apply the changes and enable Klaw to connect to the Kafka cluster using SSL protocol.


### PR DESCRIPTION
About this change - What it does
This change adds documentation on how promotion of Topics and Schemas work, including server configuration required to be set up by the superadmin.

This change also adds some clarity as to where to find the clusterid where to use it and also adds it into a couple of document pages where the information was missing.

Why this way
The hope is to provide clear concise documentation that will help users quickly integrate klaw with their organisation.
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>