### PR TITLE
Documentation for third party authentication providers

### DIFF
--- a/docs/docs/howto/authentication/third-party-account.rst
+++ b/docs/docs/howto/authentication/third-party-account.rst
@@ -36,7 +36,16 @@ To enable third-party login accounts,  you need to make the following configurat
     klaw.superadmin.default.username=superadmin@company.com
 
 
-6. If you have already signed up, you will be directed to the Klaw home page.
+6. To add the login button to the third party provider please update application.properties with the following three entries.
+::
+    # The login Url
+    klaw.sso.server.loginurl.provider.url=/oauth2/authorization/provider
+    # A URI https or local image, this is optional but can help users identify the correct provider.
+    klaw.sso.server.loginurl.provider.imageURI=
+    # The name of the provider, this simply allows users to easily identify the provider they wish to select.
+    klaw.sso.server.loginurl.github.ssoProvider=MyProvider
+
+7. If you have already signed up, you will be directed to the Klaw home page.
 
 .. image:: /../../../_static/images/authentication/OAuthLogin.png
 
@@ -44,6 +53,6 @@ To enable third-party login accounts,  you need to make the following configurat
 
 .. note:: Login page for third party account is not fully updated.
 
-7. If this is your first time logging in, you will be presented with a signup form to fill in. On submission, a request will be created for the Klaw Administrator to approve or decline.
+8. If this is your first time logging in, you will be presented with a signup form to fill in. On submission, a request will be created for the Klaw Administrator to approve or decline.
 
 .. image:: /../../../_static/images/authentication/OAuthSignupForm.png

--- a/docs/docs/howto/authentication/third-party-account.rst
+++ b/docs/docs/howto/authentication/third-party-account.rst
@@ -38,12 +38,9 @@ To enable third-party login accounts,  you need to make the following configurat
 
 6. To add the login button to the third party provider please update application.properties with the following three entries.
 ::
-    # The login Url
-    klaw.sso.server.loginurl.provider.url=/oauth2/authorization/provider
-    # A URI https or local image, this is optional but can help users identify the correct provider.
-    klaw.sso.server.loginurl.provider.imageURI=
-    # The name of the provider, this simply allows users to easily identify the provider they wish to select.
-    klaw.sso.server.loginurl.github.ssoProvider=MyProvider
+    # A https link or local image location, this is optional but can help users identify the correct provider. where {provider} is your thirdparty vendor e.g. github or okta
+    spring.security.oauth2.client.registration.{provider}.imageURI=
+
 
 7. If you have already signed up, you will be directed to the Klaw home page.
 


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change:
This change adds a small piece of information for users to be able to configure their third party providers.
Why This way
This way simplifies and minimises the amount of additional work a user needs to do.