### PR TITLE
fix: Add variable for highlighted text to fix appearance in dark mode.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,7 @@ light_css_variables = {
   "color-brand-content": _color_definitions["grey-80"],
   "color-sidebar-item-background--current": _color_definitions["grey-5"],
   "color-admonition-background": "white",
+  "color-highlighted-text": "white"
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Fixes #46 

# Note
I could not reproduce the bug locally, since the markup was not correctly rendered for unknown reasons (see screenshot, left locally, right prod).

<img width="1812" alt="wat" src="https://user-images.githubusercontent.com/943800/229452481-9f6f865a-4970-4918-b5b7-179cc46a49ce.png">

But the style in question is based on `[role="main"] . highlighted` so I just faked that locally to check if the variable update works. 

Screenshot local
<img width="893" alt="Screenshot 2023-04-03 at 10 29 42" src="https://user-images.githubusercontent.com/943800/229454843-4999ecb0-4098-4401-88e3-251c65bd6c5c.png">

