### PR TITLE
Update Workflows to include an approval table

### DIFF
--- a/docs/docs/concepts/workflows.rst
+++ b/docs/docs/concepts/workflows.rst
@@ -2,7 +2,7 @@ Workflows
 =========
 
 
-Klaw has defined workflows to apply configuration on Kafka clusters. A concept of raising a request and approving it, instead of directly creating a configuration on the cluster.
+Klaw has defined workflows to apply configuration on Kafka clusters. A concept of raising a request and approving it, this is called the `Four Eyes Principal`, instead of directly creating a configuration on the cluster.
 
 - This adds an extra layer of security avoiding risk of manual entries.
 - The requests are properly reviewed and verified by another pair of eyes, maintaining sanity of the application.
@@ -19,17 +19,189 @@ Workflows are administered by defining ownerships, roles, permissions and author
         .. note::
             Only holders of the ``USER`` role can make requests; users with the ``SUPERADMIN`` role cannot make requests, but can manage users and teams. This is the default configuration.
 
-    Topic Owner
-      Kafka has topics, and in Klaw every topic has an owner which is a Team. So all the team members would be the owners of the topic. Any request which directly or indirectly changes its configuration is coming to this team for approval. They have the right to approve or deny. This team can be producers, consumers or both or none.
-      Note that this team would be the owners of the topic (same name) in all environments. Only this team has the right to delete the topic.
+.. note::
+   Requests raised cannot be approved by the same user, rather it has to be a different user.
 
-    Subscription Owner
-      To provide security on kafka topics, subscriptions(acls) are defined. And in Klaw, every team whoever would like to produce or consume from the topic would become the subscription owner. A team can raise a subscription request (producer/consumer) on a topic, and request is sent to Topic Owner team for approval. Only this team has the right to delete the subscription, view consumer offsets, topic contents, or subscription related credentials if applicable.
+Approvals
+---------
 
-    Schema Owner
-      Klaw can integrate with Karapace or Schema registry and define schemas on a topic. Currently topic owner team can raise a schema request, and they would become the owners of the schema and its evolution.
+Different Roles
+---------------
 
-    Connectors Owner
-      Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request for a particular connector and they would become the owners of it.
+#. **Resource Owners Team** : When transferring ownership between teams the approval will come from the existing resource owner
+#. **Requestors Team** : In the majority of cases it is a member of the same team who will review and approve or decline a request.
+#. **All Approvers** : Users assigned a special permission `APPROVE_ALL_REQUESTS_TEAMS` have the ability to approve any request from any team.
+#. **Admin** : The admin user administers Klaw and is therefore mostly reviewing and approving User requests unless also assigned the permission `APPROVE_ALL_REQUESTS_TEAMS`
 
-Note that any request raised cannot be approved by the same user, rather it has to be a different user.
+User Requests
+#############
+
+.. list-table:: New User Approver matrix
+   :header-rows: 1
+   :class: no-scroll
+
+   * - Operation Type
+     - Resource Owners Team
+     - Requestors Team
+     - All Approvers
+     - Admin
+   * - User Registration Request
+     -
+     -
+     -
+     - ✅
+
+Topic Requests
+##############
+
+Topic Owner
+  Kafka has topics, and in Klaw every topic has an owner which is a Team. So all the team members would be the owners of the topic. Any request which directly or indirectly changes its configuration is coming to this team for approval. They have the right to approve or deny. This team can be producers, consumers or both or none.
+  Note that this team would be the owners of the topic (same name) in all environments. Only this team has the right to delete the topic.
+
+.. list-table:: Topic Approver matrix
+   :header-rows: 1
+   :class: no-scroll
+
+   * - Operation Type
+     - Resource Owners Team
+     - Requestors Team
+     - All Approvers
+     - Admin
+   * - New Topic Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Update Topic Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Delete Topic Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Claim Topic Request
+     - ✅
+     -
+     - ✅
+     -
+   * - Promote Topic Request
+     -
+     - ✅
+     - ✅
+     -
+
+Connector Requests
+##################
+
+Connectors Owner
+  Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request for a particular connector and they would become the owners of it.
+
+.. list-table:: Connector Approver matrix
+   :header-rows: 1
+   :class: no-scroll
+
+   * - Operation Type
+     - Resource Owners Team
+     - Requestors Team
+     - All Approvers
+     - Admin
+   * - New Connector Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Update Connector Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Delete Connector Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Claim Connector Request
+     - ✅
+     -
+     - ✅
+     -
+   * - Promote Connector Request
+     -
+     - ✅
+     - ✅
+     -
+
+Schema Requests
+###############
+
+Schema Owner
+  Klaw can integrate with Karapace or Schema registry and define schemas on a topic. Currently topic owner team can raise a schema request, and they would become the owners of the schema and its evolution.
+
+.. list-table:: Schema Approver matrix
+   :header-rows: 1
+   :class: no-scroll
+
+   * - Operation Type
+     - Resource Owners Team
+     - Requestors Team
+     - All Approvers
+     - Admin
+   * - New Schema Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Delete Schema Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Promote Schema Request
+     -
+     - ✅
+     - ✅
+     -
+
+
+.. note::
+   With Schemas there is no `Claim Schema` as it is assigned to a topic and so the Topic owner owns the Schema. Likewise there is no `Update Schema` as existing Schemas are kept and a new Schema with an incremented version is added instead.
+
+Subscription Requests
+#####################
+
+Subscription Owner
+  To provide security on kafka topics, subscriptions(acls) are defined. And in Klaw, every team whoever would like to produce or consume from the topic would become the subscription owner. A team can raise a subscription request (producer/consumer) on a topic, and request is sent to Topic Owner team for approval. Only this team has the right to delete the subscription, view consumer offsets, topic contents, or subscription related credentials if applicable.
+
+
+.. list-table:: Subscription Approver matrix
+   :header-rows: 1
+   :class: no-scroll
+
+   * - Operation Type
+     - Resource Owners Team
+     - Requestors Team
+     - All Approvers
+     - Admin
+   * - New Subscription Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Delete Subscription Request
+     -
+     - ✅
+     - ✅
+     -
+   * - Claim Subscription Request
+     - ✅
+     -
+     - ✅
+     -
+
+
+.. note::
+   When claiming a Subscription if the Subscription is owned by a team that does not own the topic then two approvals are required one by the team that owns the Subscription and one by the team that owns the topic.
+

--- a/docs/docs/concepts/workflows.rst
+++ b/docs/docs/concepts/workflows.rst
@@ -199,7 +199,7 @@ Subscription owner
 ----------------------
 
 Subscription Owner
-  In Klaw, subscriptions (ACLs) are defined to secure Kafka topics. Each team that wants to produce or consume from a topic becomes the subscription owner. Teams can submit subscription requests for a specific topic (either as a producer or consumer), which are then reviewed by the Topic Owner team for approval. The Topic Owner team alone can delete subscriptions, access consumer offsets, view topic contents, and manage any relevant subscription credentials, if applicable.
+  In Klaw, subscriptions (ACLs) are defined to secure Kafka topics. Each team that wants to produce or consume from a topic becomes the subscription owner. Teams can submit subscription requests for a specific topic (either as a producer or consumer), which are then reviewed by the Topic Owner team for approval. The Topic Owner team alone can access consumer offsets, view topic contents, and manage any relevant subscription credentials, if applicable. The Subscription owner alone has the ability to delete their subscription.
 
 Subscription request approvals
 ````````````````````````````````
@@ -221,8 +221,8 @@ The table below outlines the roles responsible for approving various subscriptio
      - ✅
      -
    * - Delete Subscription Request
-     -
      - ✅
+     -
      - ✅
      -
    * - Claim Subscription Request

--- a/docs/docs/concepts/workflows.rst
+++ b/docs/docs/concepts/workflows.rst
@@ -1,11 +1,11 @@
-Workflows
-=========
+Workflows in Klaw
+=================
 
 
 Klaw has defined workflows for applying configurations to Kafka clusters. Instead of directly creating configurations on the cluster, Klaw follows the `Four Eyes Principle` concept. This approach entails raising a request and obtaining approval before implementing any changes.
 
 
-Benefits of Workflows:
+Benefits of workflows:
 
 - It provides an additional layer of security by mitigating risks associated with manual entries.
 - Ensures a thorough review and verification of requests by another person, ensuring the sanity of the application.
@@ -16,22 +16,22 @@ Workflows in Klaw are managed by defining ownerships, roles, permissions, and au
 
 .. glossary::
 
-    Request and approval
-      One of the primary advantages of using Klaw is the governance it adds to the growing Apache Kafka® landscape. Developers can **request** new topics, schemas, ACLs, or connectors themselves. The request is then reviewed and **approved** by another member of the same team. 
+  Request and approval
+    One of the primary advantages of using Klaw is the governance it adds to the growing Apache Kafka® landscape. Developers can **request** new topics, schemas, ACLs, or connectors themselves. The request is then reviewed and **approved** by another member of the same team. 
 
-        .. note::
-            This is the default configuration. The default configuration permits only users with the  ``USER`` role to make requests. Users with the ``SUPERADMIN`` role cannot request but can manage users and teams.
+    .. note::
+      This is the default configuration. The default configuration permits only users with the  ``USER`` role to make requests. Users with the ``SUPERADMIN`` role cannot request but can manage users and teams.
 
 .. note::
    A user who raises a request cannot approve it. Instead, a different user must approve.
 
-Approvals
----------
+Approval process
+------------------
 
 In Klaw, the approval process plays an essential role in managing workflows. This process entails verifying and accepting proposed changes, making it a crucial step toward enhancing the security and governance of the system.
 
-Different Roles
-````````````````
+Roles in approval process
+``````````````````````````
 
 Within this approval process, different roles come into play, each with its unique responsibilities and permissions. These roles include:
 
@@ -41,9 +41,9 @@ Within this approval process, different roles come into play, each with its uniq
 #. **Admin** : Admin users manage Klaw, primarily reviewing and approving user requests unless they also assinged the ``APPROVE_ALL_REQUESTS_TEAMS`` permission.
 
 User Requests
-#############
+--------------
 
-The matrix below provides an understanding of the roles that approve a user registration request.
+The table below outlines the roles responsible for approving user registration requests:
 
 .. list-table:: New User Approver matrix
    :header-rows: 1
@@ -60,15 +60,18 @@ The matrix below provides an understanding of the roles that approve a user regi
      -
      - ✅
 
-Topic Requests
-##############
+Topic owner
+---------------
 
-Topic Owner
-  In Klaw, each Kafka topic is owned by a team, and all team members are considered owners. Any requests to modify the topic's configuration, whether direct or indirect, are sent to the team for approval. The team has the authority to approve or deny these requests. The team can consist of producers, consumers, or both or have no specific roles assigned.
+In Klaw, each Kafka topic is owned by a team, and all team members are considered owners. Any requests to modify the topic's configuration, whether direct or indirect, are sent to the team for approval. The team has the authority to approve or deny these requests. The team can consist of producers, consumers, or both or have no specific roles assigned.
 
   
-  .. note:: 
-      The team remains the owner of the topic across all environments. Only this team has the right to delete the topic.
+.. note:: 
+  The team remains the owner of the topic across all environments. Only this team has the right to delete the topic.
+
+Topic request approvals
+`````````````````````````
+The table below outlines the roles responsible for approving various topic-related requests:
 
 
 .. list-table:: Topic Approver matrix
@@ -106,11 +109,15 @@ Topic Owner
      - ✅
      -
 
-Connector Requests
-##################
+Connector owner
+---------------------
 
-Connectors Owner
-  Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request a specific connector, and they will become the owners of that connector.
+Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request a specific connector, and they will become the owners of that connector.
+
+
+Connector request approvals
+`````````````````````````````
+The table below outlines the roles responsible for approving various connector-related requests:
 
 .. list-table:: Connector Approver matrix
    :header-rows: 1
@@ -147,11 +154,17 @@ Connectors Owner
      - ✅
      -
 
-Schema Requests
-###############
+Schema owner
+---------------
 
 Schema Owner
   Klaw can integrate with Karapace or Schema registry and define schemas on a topic. Currently, the topic owner team can raise a schema request, and they become the owners of the schema and its evolution.
+
+
+Schema request approvals
+``````````````````````````
+
+The table below outlines the roles responsible for approving various schema-related requests:
 
 .. list-table:: Schema Approver matrix
    :header-rows: 1
@@ -182,11 +195,15 @@ Schema Owner
 .. note::
    With Schemas there is no `Claim Schema` as it is assigned to a topic and so the Topic owner owns the Schema. Likewise there is no `Update Schema` as existing Schemas are kept and a new Schema with an incremented version is added instead.
 
-Subscription Requests
-#####################
+Subscription Owner
+----------------------
 
 Subscription Owner
   In Klaw, subscriptions (ACLs) are defined to secure Kafka topics. Each team that wants to produce or consume from a topic becomes the subscription owner. Teams can submit subscription requests for a specific topic (either as a producer or consumer), which are then reviewed by the Topic Owner team for approval. The Topic Owner team alone can delete subscriptions, access consumer offsets, view topic contents, and manage any relevant subscription credentials, if applicable.
+
+Subscription Requests
+````````````````````````
+The table below outlines the roles responsible for approving various subscription-related requests:
 
 
 .. list-table:: Subscription Approver matrix

--- a/docs/docs/concepts/workflows.rst
+++ b/docs/docs/concepts/workflows.rst
@@ -2,39 +2,48 @@ Workflows
 =========
 
 
-Klaw has defined workflows to apply configuration on Kafka clusters. A concept of raising a request and approving it, this is called the `Four Eyes Principal`, instead of directly creating a configuration on the cluster.
-
-- This adds an extra layer of security avoiding risk of manual entries.
-- The requests are properly reviewed and verified by another pair of eyes, maintaining sanity of the application.
-- Information is audited. Who is raising the request, when it has been created, and who approved and when. Helps in identifying problems during unexpected behaviour of system.
-- By maintaining a history of applied changes, easy track back on the evolution of a configuration.
+Klaw has defined workflows for applying configurations to Kafka clusters. Instead of directly creating configurations on the cluster, Klaw follows the `Four Eyes Principle` concept. This approach entails raising a request and obtaining approval before implementing any changes.
 
 
-Workflows are administered by defining ownerships, roles, permissions and authorizations in Klaw. Below here are certain concepts of owners in Klaw.
+Benefits of Workflows:
+
+- It provides an additional layer of security by mitigating risks associated with manual entries.
+- Ensures a thorough review and verification of requests by another person, ensuring the sanity of the application.
+- Comprehensive information auditing, including request origin, creation time, approval details, and timestamps, enables problem identification during unexpected system behavior.
+- Easy tracking of configuration changes history, allowing for a quick overview of configuration evolution.
+
+Workflows in Klaw are managed by defining ownerships, roles, permissions, and authorizations. In the following section, you will find an overview of the key concepts related to ownership in Klaw.
 
 .. glossary::
 
     Request and approval
-      One of the biggest benefits of working with Klaw is that it adds governance to your Apache Kafka® landscape as it grows.  When a new topic, schema, ACL or connector is needed, developers **request** that item themselves.  Another member of the same team can then **approve** the request, and the item will be created.
+      One of the primary advantages of using Klaw is the governance it adds to the growing Apache Kafka® landscape. Developers can **request** new topics, schemas, ACLs, or connectors themselves. The request is then reviewed and **approved** by another member of the same team. 
+
         .. note::
-            Only holders of the ``USER`` role can make requests; users with the ``SUPERADMIN`` role cannot make requests, but can manage users and teams. This is the default configuration.
+            This is the default configuration. The default configuration permits only users with the  ``USER`` role to make requests. Users with the ``SUPERADMIN`` role cannot request but can manage users and teams.
 
 .. note::
-   Requests raised cannot be approved by the same user, rather it has to be a different user.
+   A user who raises a request cannot approve it. Instead, a different user must approve.
 
 Approvals
 ---------
 
-Different Roles
----------------
+In Klaw, the approval process plays an essential role in managing workflows. This process entails verifying and accepting proposed changes, making it a crucial step toward enhancing the security and governance of the system.
 
-#. **Resource Owners Team** : When transferring ownership between teams the approval will come from the existing resource owner
-#. **Requestors Team** : In the majority of cases it is a member of the same team who will review and approve or decline a request.
-#. **All Approvers** : Users assigned a special permission `APPROVE_ALL_REQUESTS_TEAMS` have the ability to approve any request from any team.
-#. **Admin** : The admin user administers Klaw and is therefore mostly reviewing and approving User requests unless also assigned the permission `APPROVE_ALL_REQUESTS_TEAMS`
+Different Roles
+````````````````
+
+Within this approval process, different roles come into play, each with its unique responsibilities and permissions. These roles include:
+
+#. **Resource Owners Team** : When transferring ownership between teams, the current resource owner provides the necessary approval.
+#. **Requestors Team** : Usually, a fellow team member reviews and either approves or declines a request.
+#. **All Approvers** : Users assigned the ``APPROVE_ALL_REQUESTS_TEAMS`` permission can approve any request from any team.
+#. **Admin** : Admin users manage Klaw, primarily reviewing and approving user requests unless they also assinged the ``APPROVE_ALL_REQUESTS_TEAMS`` permission.
 
 User Requests
 #############
+
+The matrix below provides an understanding of the roles that approve a user registration request.
 
 .. list-table:: New User Approver matrix
    :header-rows: 1
@@ -55,8 +64,12 @@ Topic Requests
 ##############
 
 Topic Owner
-  Kafka has topics, and in Klaw every topic has an owner which is a Team. So all the team members would be the owners of the topic. Any request which directly or indirectly changes its configuration is coming to this team for approval. They have the right to approve or deny. This team can be producers, consumers or both or none.
-  Note that this team would be the owners of the topic (same name) in all environments. Only this team has the right to delete the topic.
+  In Klaw, each Kafka topic is owned by a team, and all team members are considered owners. Any requests to modify the topic's configuration, whether direct or indirect, are sent to the team for approval. The team has the authority to approve or deny these requests. The team can consist of producers, consumers, or both or have no specific roles assigned.
+
+  
+  .. note:: 
+      The team remains the owner of the topic across all environments. Only this team has the right to delete the topic.
+
 
 .. list-table:: Topic Approver matrix
    :header-rows: 1
@@ -97,7 +110,7 @@ Connector Requests
 ##################
 
 Connectors Owner
-  Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request for a particular connector and they would become the owners of it.
+  Klaw can integrate with Kafka Connect and define various types of connectors. Any team can request a specific connector, and they will become the owners of that connector.
 
 .. list-table:: Connector Approver matrix
    :header-rows: 1
@@ -138,7 +151,7 @@ Schema Requests
 ###############
 
 Schema Owner
-  Klaw can integrate with Karapace or Schema registry and define schemas on a topic. Currently topic owner team can raise a schema request, and they would become the owners of the schema and its evolution.
+  Klaw can integrate with Karapace or Schema registry and define schemas on a topic. Currently, the topic owner team can raise a schema request, and they become the owners of the schema and its evolution.
 
 .. list-table:: Schema Approver matrix
    :header-rows: 1
@@ -173,7 +186,7 @@ Subscription Requests
 #####################
 
 Subscription Owner
-  To provide security on kafka topics, subscriptions(acls) are defined. And in Klaw, every team whoever would like to produce or consume from the topic would become the subscription owner. A team can raise a subscription request (producer/consumer) on a topic, and request is sent to Topic Owner team for approval. Only this team has the right to delete the subscription, view consumer offsets, topic contents, or subscription related credentials if applicable.
+  In Klaw, subscriptions (ACLs) are defined to secure Kafka topics. Each team that wants to produce or consume from a topic becomes the subscription owner. Teams can submit subscription requests for a specific topic (either as a producer or consumer), which are then reviewed by the Topic Owner team for approval. The Topic Owner team alone can delete subscriptions, access consumer offsets, view topic contents, and manage any relevant subscription credentials, if applicable.
 
 
 .. list-table:: Subscription Approver matrix
@@ -203,5 +216,6 @@ Subscription Owner
 
 
 .. note::
-   When claiming a Subscription if the Subscription is owned by a team that does not own the topic then two approvals are required one by the team that owns the Subscription and one by the team that owns the topic.
-
+   When claiming a Subscription, if the Subscription is owned by a team that does not own the corresponding topic, then two approvals are required: 
+    - Approval by the team that owns the Subscription.
+    - Approval by the team that owns the topic.

--- a/docs/docs/concepts/workflows.rst
+++ b/docs/docs/concepts/workflows.rst
@@ -195,14 +195,14 @@ The table below outlines the roles responsible for approving various schema-rela
 .. note::
    With Schemas there is no `Claim Schema` as it is assigned to a topic and so the Topic owner owns the Schema. Likewise there is no `Update Schema` as existing Schemas are kept and a new Schema with an incremented version is added instead.
 
-Subscription Owner
+Subscription owner
 ----------------------
 
 Subscription Owner
   In Klaw, subscriptions (ACLs) are defined to secure Kafka topics. Each team that wants to produce or consume from a topic becomes the subscription owner. Teams can submit subscription requests for a specific topic (either as a producer or consumer), which are then reviewed by the Topic Owner team for approval. The Topic Owner team alone can delete subscriptions, access consumer offsets, view topic contents, and manage any relevant subscription credentials, if applicable.
 
-Subscription Requests
-````````````````````````
+Subscription request approvals
+````````````````````````````````
 The table below outlines the roles responsible for approving various subscription-related requests:
 
 


### PR DESCRIPTION
Allow Users to see who is required to approve the different types of requests in Klaw.