### PR TITLE
Update docs regarding coral enabled default

### DIFF
--- a/docs/docs/howto/installation/run-source.rst
+++ b/docs/docs/howto/installation/run-source.rst
@@ -11,7 +11,7 @@ Klaw is a Java project. Follow the below steps to run this project from the sour
    A redesigned user interface for Browse topics, providing a new look and feel for managing Kafka topics. It consists of changes to the layout, styling, and overall appearance of the interface, as well as improvements to make browsing and working topics easier, more efficient and accessible. This new look and feel is achieved by switching to React.
 
    The redesigned UI is enabled by default since Release 2.4.0. If you want to use Klaw without the preview for now,
-   you can disabled it:
+   you can disable it:
 
    - Configure the property ``klaw.coral.enabled`` in the ``application.properties`` file to ``false`` in the module: core. 
 

--- a/docs/docs/howto/installation/run-source.rst
+++ b/docs/docs/howto/installation/run-source.rst
@@ -13,8 +13,7 @@ Klaw is a Java project. Follow the below steps to run this project from the sour
    The redesigned UI is enabled by default since Release 2.4.0. If you want to use Klaw without the preview for now,
    you can disabled it:
 
-    - Configure the property ``klaw.coral.enabled`` in the ``application.properties`` file to `false` in the module:
-    core.
+   - Configure the property ``klaw.coral.enabled`` in the ``application.properties`` file to ``false`` in the module: core. 
 
 3. Configure Cluster Api access
     - Configure the property ``klaw.clusterapi.access.base64.secret`` in the ``application.properties`` file with a base64 string in the module: core. 

--- a/docs/docs/howto/installation/run-source.rst
+++ b/docs/docs/howto/installation/run-source.rst
@@ -10,7 +10,11 @@ Klaw is a Java project. Follow the below steps to run this project from the sour
 2. Experimental UI Configuration
    A redesigned user interface for Browse topics, providing a new look and feel for managing Kafka topics. It consists of changes to the layout, styling, and overall appearance of the interface, as well as improvements to make browsing and working topics easier, more efficient and accessible. This new look and feel is achieved by switching to React.
 
-    - Configure the property ``klaw.coral.enabled`` in the ``application.properties`` file to `true` in the module: core.
+   The redesigned UI is enabled by default since Release 2.4.0. If you want to use Klaw without the preview for now,
+   you can disabled it:
+
+    - Configure the property ``klaw.coral.enabled`` in the ``application.properties`` file to `false` in the module:
+    core.
 
 3. Configure Cluster Api access
     - Configure the property ``klaw.clusterapi.access.base64.secret`` in the ``application.properties`` file with a base64 string in the module: core. 

--- a/docs/releases/release240.rst
+++ b/docs/releases/release240.rst
@@ -34,7 +34,7 @@ In this release, we have redesigned some key user interfaces using React to enha
   * *Connector restart capability*: Introducing the ability to restart Kafka connectors and their associated tasks, enabling efficient management and troubleshooting.
 
 
-To disabled the preview for the new Klaw user interface, open the ``application.properties`` file on the Klaw
+To disable the preview for the new Klaw user interface, open the ``application.properties`` file on the Klaw
 **core** module, and set the value of the following property to ``false`` (Effective this version, it is true by
 default):
 ::

--- a/docs/releases/release240.rst
+++ b/docs/releases/release240.rst
@@ -34,10 +34,12 @@ In this release, we have redesigned some key user interfaces using React to enha
   * *Connector restart capability*: Introducing the ability to restart Kafka connectors and their associated tasks, enabling efficient management and troubleshooting.
 
 
-To preview the new Klaw user interface, open the ``application.properties`` file on the Klaw **core** module, and set the value of the following property to ``true`` (Effective this version, it is true by default):
+To disabled the preview for the new Klaw user interface, open the ``application.properties`` file on the Klaw
+**core** module, and set the value of the following property to ``false`` (Effective this version, it is true by
+default):
 ::
     # Enable new Klaw user interface
-    klaw.coral.enabled=true
+    klaw.coral.enabled=false
 
 .. note::
     We are taking an incremental, feedback-driven approach in rolling out the new Klaw interfaces. By providing the feature flag to preview user interfaces, we would like you to share your valuable `feedback <https://github.com/aiven/klaw/issues/new?assignees=&labels=&template=03_feature.md>`_.


### PR DESCRIPTION
# Changes

Since release 2.4.0 the coral preview is enabled by default. This PR updates:

- the docs how to setup Klaw from source -> informs user that React UI is enabled by default and how to disabled it if they want to
- the release notes for 2.4.0 -> same as above it informs user how to disable the preview if they want to